### PR TITLE
Refactorización de modelos TwitterAccount y FacebookAccount en Publisher y más tests

### DIFF
--- a/app/assets/stylesheets/facebook_pages.scss
+++ b/app/assets/stylesheets/facebook_pages.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the FacebookPages controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -16,6 +16,10 @@
       width: 3rem;
       margin-right: .5rem;
     }
+
+    .author-name {
+      display: inline-block;
+    }
   }
   .post-image img {
     width: 100%;

--- a/app/controllers/facebook_accounts_controller.rb
+++ b/app/controllers/facebook_accounts_controller.rb
@@ -3,6 +3,9 @@ class FacebookAccountsController < ApplicationController
 
   def index
     @facebook_accounts = Current.user.facebook_accounts
+    @facebook_accounts.each do |acc|
+      acc.set_pages
+    end
   end
 
   def destroy

--- a/app/controllers/facebook_pages_controller.rb
+++ b/app/controllers/facebook_pages_controller.rb
@@ -1,0 +1,2 @@
+class FacebookPagesController < ApplicationController
+end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 class OmniauthCallbacksController < ApplicationController
   def twitter
     twitter_account = Current.user.twitter_accounts.where(username: auth.info.nickname).first_or_initialize
@@ -12,6 +14,7 @@ class OmniauthCallbacksController < ApplicationController
   end
 
   def facebook
+    puts(auth.to_json)
     facebook_account = Current.user.facebook_accounts.where(email: auth.info.email).first_or_initialize
     facebook_account.update({
       name: auth.info.name,

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :set_post, only: [:show, :edit, :update, :destroy]
-  before_action :set_fb_pages, only: [:new, :create, :update]
+  before_action :include_fb_pages, only: [:new, :create, :update]
 
   def index
     @posts = Current.user.posts.order_by(publish_at: -1)
@@ -41,16 +41,16 @@ class PostsController < ApplicationController
   private
 
     def post_params
-      params.require(:post).permit(:provider, :twitter_account_id, :facebook_account_id, :body, :publish_at, :facebook_account_page)
+      params.require(:post).permit(:publisher_id, :body, :publish_at)
     end
 
     def set_post
       @post = Current.user.posts.find_by(id: params[:id])
     end
 
-    def set_fb_pages
-      Current.user.facebook_accounts.each do |acc| 
-        acc["pages"] = acc.pages 
+    def include_fb_pages
+      Current.user.facebook_accounts.each do |acc|
+        acc["pages"] = acc.facebook_pages
       end
     end
 end

--- a/app/helpers/facebook_pages_helper.rb
+++ b/app/helpers/facebook_pages_helper.rb
@@ -1,0 +1,2 @@
+module FacebookPagesHelper
+end

--- a/app/javascript/ProviderSelector/FacebookPageProvider.jsx
+++ b/app/javascript/ProviderSelector/FacebookPageProvider.jsx
@@ -8,7 +8,7 @@ class FacebookPageProvider extends React.Component {
   render() {
     let options_pages = new Array();
     for (let i = 0; i<this.props.pages.length; i++) {
-        options_pages.push(<option value={i}>{this.props.pages[i].name}</option>)
+        options_pages.push(<option value={this.props.pages[i]._id["$oid"]}>{this.props.pages[i].name}</option>)
     }
 
     return (
@@ -16,7 +16,7 @@ class FacebookPageProvider extends React.Component {
             <label htmlFor="post_fb_user_page">
                 Facebook User Page
             </label>
-            <select className="form-control" id="post_facebook_account_page" name="post[facebook_account_page]">
+            <select className="form-control" id="post_publisher_id" name="post[publisher_id]">
                 <option value="">Select a page</option>
                 {options_pages}
             </select>

--- a/app/javascript/ProviderSelector/FacebookProvider.jsx
+++ b/app/javascript/ProviderSelector/FacebookProvider.jsx
@@ -14,7 +14,7 @@ class FacebookProvider extends React.Component {
     let options_users = new Array();
     let pages = new Array();
     for (let i = 0; i<this.props.fb_accounts.length; i++) {
-      options_users.push(<option value={this.props.fb_accounts[i]._id["$oid"]}>{this.props.fb_accounts[i].name}</option>)
+      options_users.push(<option value={this.props.fb_accounts[i].name}>{this.props.fb_accounts[i].name}</option>)
     }
 
     let UserCustomComponent = NoUser;
@@ -23,7 +23,7 @@ class FacebookProvider extends React.Component {
       UserCustomComponent = FacebookPageProvider;
 
       for (let i = 0; i<this.props.fb_accounts.length; i++) {
-        if (this.state.selectedUser == this.props.fb_accounts[i]._id["$oid"]) {
+        if (this.state.selectedUser == this.props.fb_accounts[i].name) {
           pages = this.props.fb_accounts[i].pages;
         }
       }
@@ -36,7 +36,7 @@ class FacebookProvider extends React.Component {
             <label htmlFor="post_facebook_account_id">
               Facebook User
             </label>
-            <select className="form-control" id="post_facebook_account_id" onChange={this.onUserSelected} name="post[facebook_account_id]">
+            <select className="form-control" id="facebook_account" onChange={this.onUserSelected} name="facebook_account">
               <option value="">Select an user</option>
               {options_users}
             </select>

--- a/app/javascript/ProviderSelector/TwitterProvider.jsx
+++ b/app/javascript/ProviderSelector/TwitterProvider.jsx
@@ -3,7 +3,6 @@ import React from 'react'
 class TwitterProvider extends React.Component {
   constructor(props) {
     super(props);
-    console.log(props.tw_accounts)
   }
 
   render() {
@@ -18,7 +17,7 @@ class TwitterProvider extends React.Component {
           <label htmlFor="post_twitter_account_id">
             Twitter User
           </label>
-          <select className="form-control" id="post_twitter_account_id" name="post[twitter_account_id]">
+          <select className="form-control" id="post_publisher_id" name="post[publisher_id]">
             <option value="">Select an user</option>
             {options}
           </select>

--- a/app/javascript/ProviderSelector/index.jsx
+++ b/app/javascript/ProviderSelector/index.jsx
@@ -10,8 +10,6 @@ class ProviderSelector extends React.Component {
         super(props);
         this.onProviderSelected = this.onProviderSelected.bind(this);
         this.state = { selectedProvider: null }
-        console.log('Twitter', props.tw_accounts);
-        console.log('Facebook', props.fb_accounts);
   }
 
   render() {

--- a/app/javascript/ProviderSelector/index.jsx
+++ b/app/javascript/ProviderSelector/index.jsx
@@ -10,6 +10,8 @@ class ProviderSelector extends React.Component {
         super(props);
         this.onProviderSelected = this.onProviderSelected.bind(this);
         this.state = { selectedProvider: null }
+        console.log('Twitter', props.tw_accounts);
+        console.log('Facebook', props.fb_accounts);
   }
 
   render() {
@@ -24,7 +26,7 @@ class ProviderSelector extends React.Component {
       <div>
         <div className="form-group mb-3">
           <label htmlFor="post_provider">Provider</label>
-          <select className="form-control" id="post_provider" onChange={this.onProviderSelected} name="post[provider]">
+          <select className="form-control" id="provider" onChange={this.onProviderSelected} name="provider">
             <option value="">Select a provider</option>
             <option value="Facebook">Facebook</option>
             <option value="Twitter">Twitter</option>

--- a/app/javascript/packs/provider.jsx
+++ b/app/javascript/packs/provider.jsx
@@ -9,8 +9,6 @@ document.addEventListener('turbolinks:load', () => {
     let tw_accounts = JSON.parse(element.getAttribute('tw_accounts'));
     let fb_accounts = JSON.parse(element.getAttribute('fb_accounts'));
 
-    console.log(tw_accounts);
-
     ReactDOM.render(
       <ProviderSelector tw_accounts={tw_accounts} fb_accounts={fb_accounts}/>, 
       element

--- a/app/javascript/packs/provider.jsx
+++ b/app/javascript/packs/provider.jsx
@@ -9,6 +9,8 @@ document.addEventListener('turbolinks:load', () => {
     let tw_accounts = JSON.parse(element.getAttribute('tw_accounts'));
     let fb_accounts = JSON.parse(element.getAttribute('fb_accounts'));
 
+    console.log(tw_accounts);
+
     ReactDOM.render(
       <ProviderSelector tw_accounts={tw_accounts} fb_accounts={fb_accounts}/>, 
       element

--- a/app/jobs/publisher_job.rb
+++ b/app/jobs/publisher_job.rb
@@ -6,10 +6,6 @@ class PublisherJob < ApplicationJob
     # Reschedule a tweet to the future
     return if post.publish_at > Time.current
 
-    if post.facebook?
-      post.publish_to_facebook!
-    else
-      post.publish_to_twitter!
-    end
+    post.publish_post!
   end
 end

--- a/app/models/facebook_account.rb
+++ b/app/models/facebook_account.rb
@@ -9,7 +9,7 @@ class FacebookAccount
   field :token_expires_at, type: Time
 
   belongs_to :user
-  has_many :posts, dependent: :destroy
+  has_many :facebook_pages, dependent: :destroy
 
   validates :email, uniqueness: true
 
@@ -19,5 +19,17 @@ class FacebookAccount
 
   def pages
     self.client.get_object("me/accounts")
+  end
+
+  def set_pages
+    self.pages.each do |page|
+      facebook_page = self.facebook_pages.where(page_id: page["id"]).first_or_initialize
+      facebook_page.update({
+        page_id: page["id"],
+        name: page["name"],
+        token: page["access_token"],
+        category: page["category"]
+      })
+    end
   end
 end

--- a/app/models/facebook_page.rb
+++ b/app/models/facebook_page.rb
@@ -1,0 +1,17 @@
+class FacebookPage < Publisher
+  field :page_id, type: String
+  field :category, type: String
+
+  belongs_to :facebook_account
+
+  def client
+    Koala::Facebook::API.new(token)
+  end
+
+  def publish(post)
+    fb_post = self.client.put_connections("me", "feed", {
+      message: post.body
+    })
+    return fb_post["id"]
+  end
+end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -1,0 +1,9 @@
+class Publisher
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :name, type: String
+  field :token, type: String
+
+  has_many :posts, dependent: :destroy
+end

--- a/app/models/twitter_account.rb
+++ b/app/models/twitter_account.rb
@@ -1,15 +1,9 @@
-class TwitterAccount
-  include Mongoid::Document
-  include Mongoid::Timestamps
-
-  field :name, type: String
+class TwitterAccount < Publisher
   field :username, type: String
   field :image, type: String
-  field :token, type: String
   field :secret, type: String
 
   belongs_to :user
-  has_many :posts, dependent: :destroy
 
   validates :username, uniqueness: true
 
@@ -20,5 +14,10 @@ class TwitterAccount
       config.access_token = token
       config.access_token_secret = secret
     end
+  end
+
+  def publish(post)
+    tweet = self.client.update(post.body)
+    return tweet.id
   end
 end

--- a/app/views/facebook_accounts/index.html.haml
+++ b/app/views/facebook_accounts/index.html.haml
@@ -6,8 +6,10 @@
     Connect new account
 
 - @facebook_accounts.each do |acc|
-  .d-flex.align-items-center.mb-4
-    .me-4
+  .card.mb-4
+    .card-body.d-flex.align-items-center
       = image_tag acc.image, class: 'rounded-circle me-4'
-      = acc.name
-    = button_to 'Disconnect', acc, method: :delete, data: { confirm: 'Are you sure?'}, class: 'btn btn-danger'
+      .flex-fill
+        %b= acc.name
+        .small= acc.email
+      = button_to 'Disconnect', acc, method: :delete, data: { confirm: 'Are you sure?'}, class: 'btn btn-danger flex-fill'

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -2,9 +2,19 @@
   .author
     .author-image
       -# if provisional
-      - if post.twitter_account 
-        = image_tag post.twitter_account.image, class: 'rounded-circle me-4 w-100' 
-        = link_to "@#{post.twitter_account.username}", "https://twitter.com/#{post.twitter_account.username}", class: 'link-primary', target: '_blank'
+      - if post.publisher._type.eql? "TwitterAccount"
+        = image_tag post.publisher.image, class: 'rounded-circle me-4 w-100' 
+      - else 
+        = image_tag post.publisher.facebook_account.image, class: 'rounded-circle me-4 w-100'
+
+    .author-name 
+      - if post.publisher._type.eql? "TwitterAccount"
+        %b= post.publisher.name
+        = link_to "@#{post.publisher.username}", "https://twitter.com/#{post.publisher.username}", class: 'link-primary small', target: '_blank'
+      - else
+        %b= post.publisher.facebook_account.name
+        = link_to "@#{post.publisher.name}", "https://facebook.com/#{post.publisher.page_id}", class: 'link-primary small', target: '_blank'
+
   .post-image.w-100
     -# provisional
     = image_tag "https://loremflickr.com/320/240/dog?random=#{post.id}"
@@ -15,8 +25,10 @@
         .post-date
           = "#{time_ago_in_words post.publish_at} ago"
         -# if provisional  
-        - if post.twitter_account  
-          = link_to 'View Tweet', "https://twitter.com/#{post.twitter_account.username}/status/#{post.post_id}", target: :_blank
+        - if post.publisher._type.eql? "TwitterAccount"
+          = link_to 'View Tweet', "https://twitter.com/#{post.publisher.username}/status/#{post.post_id}", target: :_blank
+        - else
+          = link_to 'View Post', "https://facebook.com/#{post.post_id}", target: :_blank
       - else
         .post-date
           Scheduled for 

--- a/app/views/twitter_accounts/index.html.haml
+++ b/app/views/twitter_accounts/index.html.haml
@@ -6,8 +6,10 @@
     Connect new account
 
 - @twitter_accounts.each do |acc|
-  .d-flex.align-items-center.mb-4
-    .me-4
+  .card.mb-4
+    .card-body.d-flex.align-items-center
       = image_tag acc.image, class: 'rounded-circle me-4'
-      = link_to "@#{acc.username}", "https://twitter.com/#{acc.username}", class: 'link-primary', target: '_blank'
-    = button_to 'Disconnect', acc, method: :delete, data: { confirm: 'Are you sure?'}, class: 'btn btn-danger'
+      .flex-fill 
+        %b= acc.name
+        = link_to "@#{acc.username}", "https://twitter.com/#{acc.username}", class: 'link-primary ms-2', target: '_blank'
+      = button_to 'Disconnect', acc, method: :delete, data: { confirm: 'Are you sure?'}, class: 'btn btn-danger'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -6,9 +6,17 @@
       %th{scope: 'col'} #
       %th{scope: 'col'} Username
       %th{scope: 'col'} Email
+      %th{scope: 'col'} Twitter Accounts
+      %th{scope: 'col'} Facebook Accounts
   %tbody
     - @users.each_with_index do |user, i|
       %tr
         %td= i + 1
         %td= user.username
         %td= user.email
+        %td
+          - user.twitter_accounts.each do |acc|
+            %div= acc.username
+        %td
+          - user.facebook_accounts.each do |acc|
+            %div= acc.email

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -10,8 +10,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     :facebook,
     Rails.application.credentials.dig(:facebook, :api_key),
     Rails.application.credentials.dig(:facebook, :api_secret),
-    # Permissions
-    scope: 'email,public_profile,pages_manage_posts,
-            pages_read_engagement'
+    scope: 'public_profile,email,pages_manage_posts,pages_read_engagement,pages_manage_ads,pages_manage_metadata,pages_show_list'
   )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
   resources :twitter_accounts
   resources :facebook_accounts
+  resources :facebook_pages
   resources :posts
 
   root 'home#index'

--- a/spec/factories/facebook_pages.rb
+++ b/spec/factories/facebook_pages.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :facebook_page do
+    
+  end
+end

--- a/spec/factories/facebook_pages.rb
+++ b/spec/factories/facebook_pages.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :facebook_page do
-    
+    sequence(:name) { |n| "Facebook Page Test #{n}" }
+    token { "EBBGfx85ToPwBADhQfqkPdJllijcNdhl0zlihZAiIh028oGMaTSGEVLu3IiM4sAYzRe6VyPfCiapvKTYeSlWCS3lhOzEOZAFu7kWXsVZAFTOvnfqqKAja6ywVI7T4gSqQItlMiyXOmcZATfujjBjHdfrhAoAB3qRD64ZA0tvBxik8hzJGGW6GZBfSgZAxDDBlSOVkecNJZBL0tQZDZD" }
+    page_id { "74854785495448584994" }
+    category { "Test Category" }
+    facebook_account
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :post do
     user { create :user_with_many_accounts, tw_counter: 1, fb_counter: 1 }
-    twitter_account { user.twitter_accounts[0] }
+    publisher { user.twitter_accounts[0] }
     sequence(:body) { |n| "Test post #{n}" }
     publish_at { DateTime.current + 7.days }
     post_id { nil }

--- a/spec/factories/publishers.rb
+++ b/spec/factories/publishers.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :publisher do
+    
+  end
+end

--- a/spec/helpers/facebook_pages_helper_spec.rb
+++ b/spec/helpers/facebook_pages_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the FacebookPagesHelper. For example:
+#
+# describe FacebookPagesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe FacebookPagesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/facebook_account_spec.rb
+++ b/spec/models/facebook_account_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe FacebookAccount, type: :model do
     it { is_expected.to have_field(:token_expires_at).of_type(Time) }
 
     it { is_expected.to belong_to(:user) }
-    it { is_expected.to have_many(:posts) }
 
     it { is_expected.to validate_uniqueness_of(:email) }
   end
@@ -31,7 +30,7 @@ RSpec.describe FacebookAccount, type: :model do
     end
 
     context 'with wrong params from scratch' do
-      subject(:post) do
+      subject(:facebook_account) do
         described_class.new(
           email: ''
         )

--- a/spec/models/facebook_page_spec.rb
+++ b/spec/models/facebook_page_spec.rb
@@ -1,5 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe FacebookPage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Document schema' do
+    it { is_expected.to be_mongoid_document }
+    it { is_expected.to have_timestamps }
+
+    it { is_expected.to have_field(:name).of_type(String) }
+    it { is_expected.to have_field(:token).of_type(String) }
+    it { is_expected.to have_field(:page_id).of_type(String) }
+    it { is_expected.to have_field(:category).of_type(String) }
+
+    it { is_expected.to have_many(:posts) }
+    it { is_expected.to belong_to(:facebook_account) }
+  end
+
+  describe '#save' do
+    context 'with params from FactoryBot' do
+      let(:facebook_account) { create :facebook_account }
+
+      subject(:facebook_page) { build :facebook_page, facebook_account: facebook_account }
+
+      it { is_expected.to be_valid }
+
+      context 'after_save' do
+        before(:each) { facebook_page.save }
+
+        it { is_expected.to be_persisted }
+      end
+    end
+
+    context 'with no Facebook account referenced' do
+      subject(:post) do
+        described_class.new(
+          name: ''
+        )
+      end
+  
+      it { is_expected.not_to be_valid }
+    end
+  end
 end

--- a/spec/models/facebook_page_spec.rb
+++ b/spec/models/facebook_page_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FacebookPage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -5,32 +5,27 @@ RSpec.describe Post, type: :model do
     it { is_expected.to be_mongoid_document }
     it { is_expected.to have_timestamps }
 
-    it { is_expected.to have_field(:provider).of_type(String) }
     it { is_expected.to have_field(:body).of_type(String) }
     it { is_expected.to have_field(:publish_at).of_type(Time) }
     it { is_expected.to have_field(:post_id).of_type(String) }
-    it { is_expected.to have_field(:facebook_account_page).of_type(Integer) }
 
     it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:twitter_account) }
-    it { is_expected.to belong_to(:facebook_account) }
+    it { is_expected.to belong_to(:publisher) }
 
     it { is_expected.to validate_length_of(:body) }
     it { is_expected.to validate_presence_of(:publish_at) }
   end
 
   describe '#save' do
-    context 'Facebook post with params from scratch' do
+    context 'Twitter post with params from scratch' do
       let(:user) { create :user }
-      let(:facebook_account) { create :facebook_account }
+      let(:twitter_account) { create :twitter_account }
 
       subject(:post) do
         described_class.new(
           user: user,
-          facebook_account: facebook_account,
-          provider: 'Facebook',
+          publisher: twitter_account,
           body: 'Test body',
-          facebook_account_page: 0 ,
           publish_at: DateTime.current + 7.days,
           post_id: nil
         )
@@ -45,15 +40,14 @@ RSpec.describe Post, type: :model do
       end
     end
 
-    context 'Twitter post with params from scratch' do
+    context 'Facebook post with params from scratch' do
       let(:user) { create :user }
-      let(:twitter_account) { create :twitter_account }
+      let(:facebook_page) { create :facebook_page }
 
       subject(:post) do
         described_class.new(
           user: user,
-          twitter_account: twitter_account,
-          provider: 'Twitter',
+          publisher: facebook_page,
           body: 'Test body',
           publish_at: DateTime.current + 7.days,
           post_id: nil
@@ -72,7 +66,6 @@ RSpec.describe Post, type: :model do
     context 'with wrong params from scratch' do
       subject(:post) do
         described_class.new(
-          provider: '',
           body: '',
           publish_at: '',
         )

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Publisher, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/facebook_pages_spec.rb
+++ b/spec/requests/facebook_pages_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "FacebookPages", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/posts_request_spec.rb
+++ b/spec/requests/posts_request_spec.rb
@@ -11,8 +11,11 @@ RSpec.describe "Posts", type: :request do
 
   context 'As user logged in' do
     let(:user) { create :user }
+    let(:facebook_account) { create :facebook_account, user: user }
     let(:twitter_account) { create :twitter_account, user: user }
+    let(:facebook_page) { create :facebook_page, facebook_account: facebook_account }
     let(:post1) { create :post, { user: user, publisher: twitter_account } }
+    let(:post2) { create :post, { user: user, publisher: facebook_page } }
 
     before(:each) { login_as user }
 
@@ -34,11 +37,32 @@ RSpec.describe "Posts", type: :request do
       end
     end
 
-    describe 'POST #create' do
+    describe 'POST #create for Twitter' do
       let(:params) do
         {
           post: {
             publisher_id: twitter_account.id.to_s,
+            body: 'body test',
+            publish_at: (DateTime.current + 7.days).to_s
+          }
+        }  
+      end
+
+      it 'creates a new post and redirect to posts index' do
+        post posts_url, params: params
+
+        expect(response).to redirect_to(:posts)
+        follow_redirect!
+
+        expect(response.body).to include('Post was scheduled successfully')
+      end
+    end
+
+    describe 'POST #create for Facebook' do
+      let(:params) do
+        {
+          post: {
+            publisher_id: facebook_page.id.to_s,
             body: 'body test',
             publish_at: (DateTime.current + 7.days).to_s
           }
@@ -83,7 +107,7 @@ RSpec.describe "Posts", type: :request do
       end
     end
 
-    describe 'PUT #update' do
+    describe 'PUT #update a Twitter post' do
       let(:params) do
         {
           post: {
@@ -96,6 +120,27 @@ RSpec.describe "Posts", type: :request do
 
       it 'update post and redirect to posts index' do
         put "#{posts_url}/#{post1.id}", params: params
+
+        expect(response).to redirect_to(:posts)
+        follow_redirect!
+
+        expect(response.body).to include('Post was updated successfully')
+      end
+    end
+
+    describe 'PUT #update a Facebook post' do
+      let(:params) do
+        {
+          post: {
+            publisher_id: facebook_page.id.to_s,
+            body: 'body test updated',
+            publish_at: (DateTime.current + 7.days).to_s
+          }
+        }  
+      end
+
+      it 'update post and redirect to posts index' do
+        put "#{posts_url}/#{post2.id}", params: params
 
         expect(response).to redirect_to(:posts)
         follow_redirect!

--- a/spec/requests/posts_request_spec.rb
+++ b/spec/requests/posts_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Posts", type: :request do
   context 'As user logged in' do
     let(:user) { create :user }
     let(:twitter_account) { create :twitter_account, user: user }
-    let(:post1) { create :post, { user: user, twitter_account: twitter_account } }
+    let(:post1) { create :post, { user: user, publisher: twitter_account } }
 
     before(:each) { login_as user }
 
@@ -38,7 +38,7 @@ RSpec.describe "Posts", type: :request do
       let(:params) do
         {
           post: {
-            twitter_account_id: twitter_account.id.to_s,
+            publisher_id: twitter_account.id.to_s,
             body: 'body test',
             publish_at: (DateTime.current + 7.days).to_s
           }
@@ -59,7 +59,7 @@ RSpec.describe "Posts", type: :request do
       let(:fake_params) do
         {
           post: {
-            twitter_account_id: '9873645',
+            publisher_id: '9873645',
             body: 'body test',
             publish_at: (DateTime.current + 7.days).to_s
           }
@@ -87,7 +87,7 @@ RSpec.describe "Posts", type: :request do
       let(:params) do
         {
           post: {
-            twitter_account_id: twitter_account.id.to_s,
+            publisher_id: twitter_account.id.to_s,
             body: 'body test updated',
             publish_at: (DateTime.current + 7.days).to_s
           }
@@ -108,7 +108,7 @@ RSpec.describe "Posts", type: :request do
       let(:fake_params) do
         {
           post: {
-            twitter_account_id: twitter_account.id.to_s,
+            publisher_id: twitter_account.id.to_s,
             body: '',
             publish_at: (DateTime.current + 7.days).to_s
           }

--- a/spec/system/providers_spec.rb
+++ b/spec/system/providers_spec.rb
@@ -11,29 +11,29 @@ RSpec.describe "Providers", type: :system do
   end
 
   it 'should render Provider select in React component' do
-    expect(page).to have_select('Provider');
+    expect(page).to have_select('provider');
   end
 
   it 'should render Twitter User select in React component' do
-    select('Twitter', from:'Provider')
-    expect(page).to have_select('Twitter User')
+    select('Twitter', from:'provider')
+    expect(page).to have_select('post_publisher_id')
   end
 
   it 'should render Facebook User select in React component' do
-    select('Facebook', from:'Provider')
-    expect(page).to have_select('Facebook User')
+    select('Facebook', from:'provider')
+    expect(page).to have_select('facebook_account')
   end
 
   it 'should not render Twitter or Facebook User select in React component' do
-    select('Select a provider', from:'Provider')
-    expect(page).to_not have_select('Facebook User')
-    expect(page).to_not have_select('Twitter User')
+    select('Select a provider', from:'provider')
+    expect(page).to_not have_select('facebook_account')
+    expect(page).to_not have_select('post_publisher_id')
   end
 
   it 'should not render Facebook User Page select in React component' do
-    select('Facebook', from:'Provider')
-    select('Select an user', from:'Facebook User')
-    expect(page).to_not have_select('Facebook User Page')
+    select('Facebook', from:'provider')
+    select('Select an user', from:'facebook_account')
+    expect(page).to_not have_select('post_publisher_id')
   end
 
 end


### PR DESCRIPTION
Se ha hecho una refactorización de los modelos de TwitterAccount y Facebook Account de manera que se ha creado un modelo padre Publisher del que heredan TwitterAccount y un nuevo modelo FacebookPage, siendo ambos los que publican en las respectivas redes sociales. FacebookAccount sigue existiendo y tiene una relación de _has_many_ con FacebookPage.