### PR TITLE
Botón para actualizar FacebookPages

### DIFF
--- a/app/controllers/facebook_accounts_controller.rb
+++ b/app/controllers/facebook_accounts_controller.rb
@@ -3,7 +3,15 @@ class FacebookAccountsController < ApplicationController
 
   def index
     @facebook_accounts = Current.user.facebook_accounts
-    @facebook_accounts.each(&:set_pages)
+  end
+
+  def refresh_pages
+    @facebook_accounts = Current.user.facebook_accounts
+    if @facebook_accounts
+      @facebook_accounts.each(&:set_pages)
+      notice = 'Successfully updated Facebook Pages'
+    end
+    redirect_to facebook_accounts_url, notice: notice || 'Unable to refresh Facebook Pages'
   end
 
   def destroy

--- a/app/controllers/facebook_accounts_controller.rb
+++ b/app/controllers/facebook_accounts_controller.rb
@@ -3,9 +3,7 @@ class FacebookAccountsController < ApplicationController
 
   def index
     @facebook_accounts = Current.user.facebook_accounts
-    @facebook_accounts.each do |acc|
-      acc.set_pages
-    end
+    @facebook_accounts.each(&:set_pages)
   end
 
   def destroy

--- a/app/models/facebook_account.rb
+++ b/app/models/facebook_account.rb
@@ -14,16 +14,16 @@ class FacebookAccount
   validates :email, uniqueness: true
 
   def client
-    Koala::Facebook::API.new(token)
+    @client = Koala::Facebook::API.new(token)
   end
 
   def pages
-    self.client.get_object("me/accounts")
+    @pages = client.get_object("me/accounts")
   end
 
   def set_pages
-    self.pages.each do |page|
-      facebook_page = self.facebook_pages.where(page_id: page["id"]).first_or_initialize
+    pages.each do |page|
+      facebook_page = facebook_pages.where(page_id: page["id"]).first_or_initialize
       facebook_page.update({
         page_id: page["id"],
         name: page["name"],

--- a/app/models/facebook_account.rb
+++ b/app/models/facebook_account.rb
@@ -22,6 +22,14 @@ class FacebookAccount
   end
 
   def set_pages
+    current_pages = facebook_pages.all
+    current_pages.each do |cpage|
+      page = pages.find { |page| page["id"].eql? cpage["page_id"] }
+      if !page
+        cpage.delete
+      end
+    end
+
     pages.each do |page|
       facebook_page = facebook_pages.where(page_id: page["id"]).first_or_initialize
       facebook_page.update({

--- a/app/models/facebook_account.rb
+++ b/app/models/facebook_account.rb
@@ -24,8 +24,8 @@ class FacebookAccount
   def set_pages
     current_pages = facebook_pages.all
     current_pages.each do |cpage|
-      page = pages.find { |page| page["id"].eql? cpage["page_id"] }
-      if !page
+      page = pages.find { |page| page["id"].eql? cpage.page_id }
+      unless page
         cpage.delete
       end
     end

--- a/app/models/facebook_page.rb
+++ b/app/models/facebook_page.rb
@@ -5,11 +5,11 @@ class FacebookPage < Publisher
   belongs_to :facebook_account
 
   def client
-    Koala::Facebook::API.new(token)
+    @client = Koala::Facebook::API.new(token)
   end
 
   def publish(post)
-    fb_post = self.client.put_connections("me", "feed", {
+    fb_post = client.put_connections("me", "feed", {
       message: post.body
     })
     return fb_post["id"]

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,7 +15,7 @@ class Post
   validates :publish_at, presence: true
 
   after_initialize do
-    self.publish_at ||= 1.minute.from_now
+    publish_at ||= 1.minute.from_now
   end
   
   after_save do

--- a/app/models/twitter_account.rb
+++ b/app/models/twitter_account.rb
@@ -17,7 +17,7 @@ class TwitterAccount < Publisher
   end
 
   def publish(post)
-    tweet = self.client.update(post.body)
+    tweet = client.update(post.body)
     return tweet.id
   end
 end

--- a/app/views/facebook_accounts/index.html.haml
+++ b/app/views/facebook_accounts/index.html.haml
@@ -4,6 +4,9 @@
   = button_to 'auth/facebook', method: :post, class: 'btn btn-primary' do
     %i.bi.bi-facebook.icon_mr
     Connect new account
+  = button_to refresh_pages_facebook_accounts_url, method: :get, class: 'btn btn-success' do
+    %i.bi.bi-facebook.icon_mr
+    Refresh Pages
 
 - @facebook_accounts.each do |acc|
   .card.mb-4

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -2,13 +2,13 @@
   .author
     .author-image
       -# if provisional
-      - if post.publisher._type.eql? "TwitterAccount"
+      - if post.publisher.kind_of?(TwitterAccount)
         = image_tag post.publisher.image, class: 'rounded-circle me-4 w-100' 
       - else 
         = image_tag post.publisher.facebook_account.image, class: 'rounded-circle me-4 w-100'
 
     .author-name 
-      - if post.publisher._type.eql? "TwitterAccount"
+      - if post.publisher.kind_of?(TwitterAccount)
         %b= post.publisher.name
         = link_to "@#{post.publisher.username}", "https://twitter.com/#{post.publisher.username}", class: 'link-primary small', target: '_blank'
       - else
@@ -25,7 +25,7 @@
         .post-date
           = "#{time_ago_in_words post.publish_at} ago"
         -# if provisional  
-        - if post.publisher._type.eql? "TwitterAccount"
+        - if post.publisher.kind_of?(TwitterAccount)
           = link_to 'View Tweet', "https://twitter.com/#{post.publisher.username}/status/#{post.post_id}", target: :_blank
         - else
           = link_to 'View Post', "https://facebook.com/#{post.post_id}", target: :_blank

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,11 @@ Rails.application.routes.draw do
   get '/auth/facebook/callback', to: 'omniauth_callbacks#facebook'
 
   resources :twitter_accounts
-  resources :facebook_accounts
-  resources :facebook_pages
+  resources :facebook_accounts do
+    collection do
+      get 'refresh_pages'
+    end
+  end
   resources :posts
 
   root 'home#index'

--- a/spec/factories/facebook_accounts.rb
+++ b/spec/factories/facebook_accounts.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :facebook_account do
     sequence(:name) { |n| "Facebook Test User #{n}" }
     sequence(:email) { |n| "facebooktestuser#{n}@test.com" }
-    image { "http://graph.facebook.com/v4.0/352914279210567/picture?access_token=EAAGfx85ToPwBADhQfqkPdJllijcNdhl0zlihZAiIh028oGMaTSGEVLu3IiM4sAYzRe6VyPfCiapvKTYeSlWCS3lhOzEOZAFu7kWXsVZAFTOvnfqqKAjd6ywVI7T4gSqQItlMiAXOmcZATfujjBjHdfrhAoAB3qRD6aZA0tvBxik8hzJGGW6GZBfSgZAxDDBlSOVkecNJZBL0tQZDZD" }
-    token { "EAAGfx85ToPwBADhQfqkPdJllijcNdhl0zlihZAiIh028oGMaTSGEVLu3IiM4sAYzRe6VyPfCiapvKTYeSlWCS3lhOzEOZAFu7kWXsVZAFTOvnfqqKAjd6ywVI7T4gSqQItlMiAXOmcZATfujjBjHdfrhAoAB3qRD6aZA0tvBxik8hzJGGW6GZBfSgZAxDDBlSOVkecNJZBL0tQZDZD" }
+    image { "http://graph.facebook.com/testimage" }
+    token { "XXXXXXXXXXXXXX" }
     token_expires_at { DateTime.current + 7.days }
     user
   end

--- a/spec/factories/facebook_pages.rb
+++ b/spec/factories/facebook_pages.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :facebook_page do
     sequence(:name) { |n| "Facebook Page Test #{n}" }
-    token { "EBBGfx85ToPwBADhQfqkPdJllijcNdhl0zlihZAiIh028oGMaTSGEVLu3IiM4sAYzRe6VyPfCiapvKTYeSlWCS3lhOzEOZAFu7kWXsVZAFTOvnfqqKAja6ywVI7T4gSqQItlMiyXOmcZATfujjBjHdfrhAoAB3qRD64ZA0tvBxik8hzJGGW6GZBfSgZAxDDBlSOVkecNJZBL0tQZDZD" }
-    page_id { "74854785495448584994" }
+    token { "XXXXXXXXXXXXXXXXX" }
+    page_id { "9999999999999" }
     category { "Test Category" }
     facebook_account
   end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     post_id { nil }
 
     factory :published_post do
-      post_id { '1372176407267250182' }
+      post_id { '00000000000' }
     end
   end
 end

--- a/spec/factories/publishers.rb
+++ b/spec/factories/publishers.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :publisher do
-    
+    sequence(:name) { |n| "Publisher Test #{n}" }
+    token { "XXXXXXXXXXXXXXXXX" }
   end
 end

--- a/spec/factories/twitter_accounts.rb
+++ b/spec/factories/twitter_accounts.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :twitter_account do
     sequence(:name) { |n| "Twitter Test User #{n}" }
     sequence(:username) { |n| "twittertestuser#{n}" }
-    image { "http://pbs.twimg.com/profile_images/1362493981775581184/By6QKkhM_normal.jpg" }
-    token { "1362493740447842304-K3wiBLjZSzbKsWwzJXcVNhiKXxpSfO" }
-    secret { "9SUdTu0oWSXhLJEx65b8rnoUU7Gl9gdTh6r730w2Imvzv" }
+    image { "http://pbs.twimg.com/profile_images/testimage" }
+    token { "XXXXXXXXXXXXXXX" }
+    secret { "YYYYYYYYYYYYYY" }
     user
   end
 end

--- a/spec/requests/facebook_accounts_request_spec.rb
+++ b/spec/requests/facebook_accounts_request_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe "FacebookAccounts", type: :request do
       end
     end
 
+    describe 'GET #refresh_pages' do
+      it 'refresh Facebook pages succesfully' do
+        get refresh_pages_facebook_accounts_url
+
+        expect(response).to redirect_to(:facebook_accounts)
+        follow_redirect!
+        expect(response.body).to include ("Successfully updated Facebook Pages")
+      end
+    end
+
     describe 'DELETE #destroy' do
       it 'destroy facebook account and redirect to facebook accounts index' do
         delete "#{facebook_accounts_url}/#{account.id}"


### PR DESCRIPTION
Se ha añadido un botón para poder refrescar o actualizar las páginas de Facebook asociadas a cada una de las cuentas de Facebook vinculadas, de manera que las nuevas páginas aparezcan reflejadas en la aplicación y las páginas borradas no lo estén.